### PR TITLE
standardise onelogin strategy with other strategies

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 # App
-HOST=127.0.0.1
+HOST=localhost
 PORT=3000
 
-#DB
+# DB
 POSTGRES_URL=postgres://postgres:password@localhost/test
 REDIS_URL=redis://localhost:6379/10
 
@@ -17,3 +17,9 @@ GOOGLE_CALLBACK_URL=http://localhost:3000/auth/google/callback
 FACEBOOK_CLIENT_ID=XXX
 FACEBOOK_CLIENT_SECRET=XXX
 FACEBOOK_CALLBACK_URL=http://localhost:3000/auth/facebook/callback
+
+ONELOGIN_CLIENT_ID=XXX
+ONELOGIN_CLIENT_SECRET=XXX
+ONELOGIN_REDIRECT_URI=http://localhost:3000/auth/onelogin/callback
+ONELOGIN_SUBDOMAIN=XXX
+ONELOGIN_SCOPE=openid profile email

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,7 +4,7 @@ import {promisify} from "util";
 
 import {Public, User} from "../common/decorators";
 import {IUserCreateFields} from "../user/interfaces";
-import {FacebookGuard, GoogleGuard, LoginGuard} from "../common/guards";
+import {LoginGuard, FacebookGuard, GoogleGuard, OneloginGuard} from "../common/guards";
 import {UserEntity} from "../user/user.entity";
 import {UserService} from "../user/user.service";
 
@@ -107,14 +107,14 @@ export class AuthController {
   }
 
   @Public()
-  @UseGuards(LoginGuard)
-  @Get("onelogin/login")
+  @UseGuards(OneloginGuard)
+  @Get("onelogin")
   public oneloginLogin(): void {
     // initiates the OneLogin login flow
   }
 
   @Public()
-  @UseGuards(LoginGuard)
+  @UseGuards(OneloginGuard)
   @Get("onelogin/callback")
   public oneloginLoginCallback(@User() user: UserEntity): UserEntity {
     return user;

--- a/src/common/guards/facebook.ts
+++ b/src/common/guards/facebook.ts
@@ -1,8 +1,8 @@
-import {ExecutionContext, Injectable} from "@nestjs/common";
+import {CanActivate, ExecutionContext, Injectable} from "@nestjs/common";
 import {AuthGuard} from "@nestjs/passport";
 
 @Injectable()
-export class FacebookGuard extends AuthGuard("facebook") {
+export class FacebookGuard extends AuthGuard("facebook") implements CanActivate {
   public async canActivate(context: ExecutionContext): Promise<boolean> {
     const result = (await super.canActivate(context)) as boolean;
     const request = context.switchToHttp().getRequest();

--- a/src/common/guards/index.ts
+++ b/src/common/guards/index.ts
@@ -2,4 +2,5 @@ export * from "./local";
 export * from "./login";
 export * from "./google";
 export * from "./facebook";
+export * from "./onelogin";
 export * from "./roles";

--- a/src/common/guards/onelogin.ts
+++ b/src/common/guards/onelogin.ts
@@ -2,7 +2,7 @@ import {CanActivate, ExecutionContext, Injectable} from "@nestjs/common";
 import {AuthGuard} from "@nestjs/passport";
 
 @Injectable()
-export class GoogleGuard extends AuthGuard("google") implements CanActivate {
+export class OneloginGuard extends AuthGuard("onelogin") implements CanActivate {
   public async canActivate(context: ExecutionContext): Promise<boolean> {
     const result = (await super.canActivate(context)) as boolean;
     const request = context.switchToHttp().getRequest();

--- a/src/env.ts
+++ b/src/env.ts
@@ -31,9 +31,11 @@ declare global {
       FACEBOOK_CLIENT_SECRET: string;
       FACEBOOK_CALLBACK_URL: string;
 
-      ONELOGIN_SUBDOMAIN: string;
       ONELOGIN_CLIENT_ID: string;
       ONELOGIN_CLIENT_SECRET: string;
+      ONELOGIN_REDIRECT_URI: string;
+      ONELOGIN_SUBDOMAIN: string;
+      ONELOGIN_SCOPE: string;
     }
   }
 }


### PR DESCRIPTION
I tried to execute the auth flow but I was struggling too much with setting up postgres and redis so I am not sure if it works 100%. It returns the callback from Onelogin with the tokenset, so it looks ok. I had issues with persisting the session cookie which is probably because I failed to validate without a real UserEntity.